### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-    # @items = Item.all.order(created_at: :desc)
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,38 +125,41 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+      <% @items.each do |item| %>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓商品のインスタンス変数になにか入っている場合に中身のすべてを展開 %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> 
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.burden.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
-        <% end %>
+          <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
+      <%# //↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑商品のインスタンス変数になにか入っている場合に中身のすべてを展開 %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示  されないようにしましょう %>
+      <%# 商品がない場合は以下のダミー商品を表示 %>
+    <% if @items.empty? %>
+      <%# ↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓商品がある場合は表示されない %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= link_to image_tag("sample.jpeg", class:"item-img"), "#" %>
@@ -174,8 +177,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+      <%# //↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑商品がある場合は表示されない %>
+      <%# //↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑商品がない場合は以下のダミー商品を表示 %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  # resources :items do
-  #   resources :deliveries, only: [:index, :create]
-  # end
+  resources :items
+  
 end


### PR DESCRIPTION
# what
商品一覧表示機能の実装

# why
商品一覧表示機能を実装するため

# 補足
sold outの表記は実装していません

# プルリクエストへ記載するgyazo
## 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/82eff1fb6dcb174839f3c56407d86a4a

## 商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/dc7314d07579260602e8a9fd090c0e89